### PR TITLE
Remove obsolete `BaseChecker.__implements__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed minimum Python version to 3.8.X
 
+### Fixed
+
+- Compatibility with Pylint 3.0
+
 ### Repository
 
 - Replace most Python pre-commit hooks with [ruff](https://beta.ruff.rs/docs/)

--- a/pylint_secure_coding_standard.py
+++ b/pylint_secure_coding_standard.py
@@ -23,7 +23,6 @@ from typing import ClassVar
 
 import astroid
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
 
 # ==============================================================================
 # Helper functions
@@ -383,8 +382,6 @@ class SecureCodingStandardChecker(BaseChecker):  # pylint: disable=too-many-inst
     """Plugin class."""
 
     DEFAULT_MAX_MODE = 0o755
-
-    __implements__ = (IAstroidChecker,)
 
     name = 'secure-coding-standard'
     options = (


### PR DESCRIPTION
... for compatibility against Pylint 3.0.

Bye :wave: