### PR TITLE
Fixes configuration options retrieval on Pylint 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Configuration options retrieval on Pylint 3
+
 ### Repository
 
 - Update `astral-sh/ruff-pre-commit` hook to v0.1.6

--- a/pylint_secure_coding_standard.py
+++ b/pylint_secure_coding_standard.py
@@ -723,7 +723,7 @@ def load_configuration(linter):  # pragma: no cover
     """Load data from the configuration file."""
     for checker in linter.get_checkers():
         if isinstance(checker, SecureCodingStandardChecker):
-            checker.set_os_open_allowed_modes(checker.config.os_open_mode)
-            checker.set_os_mkdir_allowed_modes(checker.config.os_mkdir_mode)
-            checker.set_os_mkfifo_allowed_modes(checker.config.os_mkfifo_mode)
-            checker.set_os_mknod_allowed_modes(checker.config.os_mknod_mode)
+            checker.set_os_open_allowed_modes(checker.linter.config.os_open_mode)
+            checker.set_os_mkdir_allowed_modes(checker.linter.config.os_mkdir_mode)
+            checker.set_os_mkfifo_allowed_modes(checker.linter.config.os_mkfifo_mode)
+            checker.set_os_mknod_allowed_modes(checker.linter.config.os_mknod_mode)


### PR DESCRIPTION
Related to <https://github.com/pylint-dev/pylint/commit/2f7cb9870c61592bf663359fb21250e007c022fe>.

---

This patch fixes the following traceback :

```
Traceback (most recent call last):
  File "[...]/venv/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "[...]/venv/lib/python3.9/site-packages/pylint/__init__.py", line 34, in run_pylint
    PylintRun(argv or sys.argv[1:])
  File "[...]/venv/lib/python3.9/site-packages/pylint/lint/run.py", line 162, in __init__
    args = _config_initialization(
  File "[...]/venv/lib/python3.9/site-packages/pylint/config/config_initialization.py", line 134, in _config_initialization
    linter.load_plugin_configuration()
  File "[...]/venv/lib/python3.9/site-packages/pylint/lint/pylinter.py", line 408, in load_plugin_configuration
    module_or_error.load_configuration(self)
  File "[...]/venv/lib/python3.9/site-packages/pylint_secure_coding_standard.py", line 726, in load_configuration
    checker.set_os_open_allowed_modes(checker.config.os_open_mode)
AttributeError: 'SecureCodingStandardChecker' object has no attribute 'config'
```